### PR TITLE
avoid error if not found reservation.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # This GitHub action can publish assets for release when a tag is created.
-# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
+# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.1).
 #
 # This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your 
 # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 2023.01.21 - v0.1.0
+
+### Added
++ Provider azureipam
++ Resource reservation
++ Data reservation
+
+### Fixed
+
+
+## 2023.02.20 - v0.1.1
+
+### Added
+
+### Fixed
++ Provider azureipam `api_url` param can also be sourced from the `AZUREIPAM_API_URL` Environment Variable.
++ Avoid error when reservation is not found in redeployments (see [Special Considerations](https://registry.terraform.io/providers/XtratusCloud/azureipam/latest/docs#special-considerations))

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=xtratuscloud
 NAMESPACE=local
 NAME=azureipam
 BINARY=terraform-provider-${NAME}
-VERSION=0.1
+VERSION=0.1.1
 OS_ARCH=linux_amd64
 
 default: install

--- a/azureipam/provider.go
+++ b/azureipam/provider.go
@@ -15,8 +15,9 @@ func Provider() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"api_url": {
 				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The root url of the APIM REST API solution to be used, without the /api url suffix",
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("AZUREIPAM_API_URL", nil),
+				Description: "The root url of the APIM REST API solution to be used, without the /api url suffix. Must be also assigned at AZUREIPAM_API_URL environment variable.",
 			},
 			"token": {
 				Type:        schema.TypeString,

--- a/azureipam/resource_reservation.go
+++ b/azureipam/resource_reservation.go
@@ -87,9 +87,8 @@ func resourceReservationRead(ctx context.Context, d *schema.ResourceData, m inte
 	//read reservation
 	reservation, err := c.GetReservation(space, block, id)
 	if err != nil {
-		return diag.FromErr(err)
+		flattenReservation(nil, space, block, d)
 	}
-
 	flattenReservation(reservation, space, block, d)
 
 	return diags
@@ -145,10 +144,15 @@ func resourceReservationDelete(ctx context.Context, d *schema.ResourceData, m in
 func flattenReservation(reservation *cli.Reservation, space, block string, d *schema.ResourceData) {
 	d.Set("space", space)
 	d.Set("block", block)
-	d.Set("id", reservation.Id)
-	d.Set("cidr", reservation.Cidr)
-	d.Set("user_id", reservation.UserId)
-	d.Set("created_on", time.Unix(int64(reservation.CreatedOn), 0).Format(time.RFC1123))
-	d.Set("status", reservation.Status)
-	d.Set("tags", reservation.Tags)
+	if reservation != nil {
+		d.Set("id", reservation.Id)
+		d.Set("cidr", reservation.Cidr)
+		d.Set("user_id", reservation.UserId)
+		d.Set("created_on", time.Unix(int64(reservation.CreatedOn), 0).Format(time.RFC1123))
+		d.Set("status", reservation.Status)
+		d.Set("tags", reservation.Tags)
+	} else {
+		//The IPAM reservation is deleted after vnet is created, to avoid exception take information from current state values
+		d.Set("status", "not_found")
+	}
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ Do not keep your authentication token in HCL, use Terraform environment variable
 terraform {
   required_providers {
     azureipam = {
-      version = "0.1.0"
+      version = "0.1.1"
       source  = "xtratuscloud/azureipam"
     }
   }
@@ -30,7 +30,7 @@ terraform {
 
 ## get an access token for ipam engine application
 data "external" "get_access_token" {
-  program = ["az", "account", "get-access-token", "--resource", "api://fb09120f-xxxx-4d82-91d8-xxxxxxxxxxxx"]
+  program = ["az", "account", "get-access-token", "--resource", "api://d47d5cd9-b599-4a6a-9d54-254565ff08de"]
 }
 
 # Configure the Azure IPAM provider
@@ -50,5 +50,9 @@ resource "azureipam_reservation" "example" {
 
 ## Argument Reference
 
-- **api_url** (Required) The root url of the APIM REST API solution to be used, without the /api url suffix.
-- **token** (Optional) The bearer token to be used when authenticating to the API. Must be also assigned at AZUREIPAM_TOKEN environment variable.
+* `api_url` - (Optional) The root url of the APIM REST API solution to be used, without the /api url suffix. This can also be sourced from the `AZUREIPAM_API_URL` Environment Variable.
+* `token` - (Optional) The bearer token to be used when authenticating to the API. This can also be sourced from the `AZUREIPAM_TOKEN` Environment Variable.
+
+
+## Special Considerations
+Due to the current behaviour of the IPAM application, as the reservation is deleted once the vnet is deployed, an error avoidance mechanism has been implemented, which takes the current values when trying to update the state. This mechanism assumes that the reservation search is only performed when the element is already in the tfstate, to refresh the state information if needed, and it's not performed in the initial plan.

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     azureipam = {
-      version = "0.1.0"
-      source  = "xtratuscloud/azureipam"
+      version = "0.1.1"
+      source  = "xtratuscloud/local/azureipam"
     }
   }
 }

--- a/ipamclient/reservation.go
+++ b/ipamclient/reservation.go
@@ -46,7 +46,7 @@ func (c *Client) GetReservation(space, block, id string) (*Reservation, error) {
 		}
 	}
 
-	//not found
+	//not found - Azure IPAM delete the reservation after the vnet is deployed.
 	return nil, fmt.Errorf("Reservation not found: %s", id)
 }
 


### PR DESCRIPTION
+ Provider azureipam `api_url` param can also be sourced from the `AZUREIPAM_API_URL` Environment Variable.
+ Avoid error when reservation is not found in redeployments