### PR TITLE
fix: update import regexp to match with ipam naming restrictions

### DIFF
--- a/internal/provider/block_network_resource.go
+++ b/internal/provider/block_network_resource.go
@@ -238,7 +238,7 @@ func (r *blockNetworkResource) Configure(_ context.Context, req resource.Configu
 
 func (r *blockNetworkResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// Retrieve import ID, validate, split and save to id attribute
-	re := regexp.MustCompile("^(?<space>[a-zA-Z0-9]*)/(?<block>[a-zA-Z0-9]*)/(?<id>/subscriptions/(?<SubscriptionId>.*)/resourceGroups/(?<ResourceGroupName>.*)/providers/(?<ResourceProviderNamespace>.*)/(?<ResourceType>.*)/(?<ResourceName>.*))$")
+	re := regexp.MustCompile("^(?<space>[a-zA-Z0-9\\._-]*)/(?<block>[a-zA-Z0-9\\._-]*)/(?<id>/subscriptions/(?<SubscriptionId>.*)/resourceGroups/(?<ResourceGroupName>.*)/providers/(?<ResourceProviderNamespace>.*)/(?<ResourceType>.*)/(?<ResourceName>.*))$")
 	
 	//validate
 	if !re.MatchString(req.ID) {

--- a/internal/provider/block_resource.go
+++ b/internal/provider/block_resource.go
@@ -229,7 +229,7 @@ func (r *blockResource) Configure(_ context.Context, req resource.ConfigureReque
 
 func (r *blockResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// Retrieve import ID, validate, split and save to id attribute
-	re := regexp.MustCompile("^(?<space>[a-zA-Z0-9]*)/(?<block>[a-zA-Z0-9]*)$")
+	re := regexp.MustCompile("^(?<space>[a-zA-Z0-9\\._-]*)/(?<block>[a-zA-Z0-9\\._-]*)$")
 	//validate
 	if !re.MatchString(req.ID) {
 		resp.Diagnostics.AddError(

--- a/internal/provider/external_resource.go
+++ b/internal/provider/external_resource.go
@@ -245,7 +245,7 @@ func (r *externalResource) Configure(_ context.Context, req resource.ConfigureRe
 
 func (r *externalResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// Retrieve import ID, validate, split and save to id attribute
-	re := regexp.MustCompile("^(?<space>[a-zA-Z0-9]*)/(?<block>[a-zA-Z0-9]*)/(?<name>[a-zA-Z0-9]*)$")
+	re := regexp.MustCompile("^(?<space>[a-zA-Z0-9\\._-]*)/(?<block>[a-zA-Z0-9\\._-]*)/(?<name>[a-zA-Z0-9\\._-]*)$")
 	//validate
 	if !re.MatchString(req.ID) {
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
Hey! 👋 

Thanks for maintaining this Terraform provider!

We had an issue importing our existing resources in IPAM, which turned out to be a mismatch in allowed characters in the import regex. This pull request should solve that, updating the regexp patterns to match the allowed patterns in Azure IPAM (adding `.`, `-` and `_`, `^(?![\._-])([a-zA-Z0-9\._-]){1,64}(?<![\._-])$`).

See name regex here: https://github.com/Azure/ipam/blob/main/engine/app/routers/space.py#L48-L56